### PR TITLE
Adds phing

### DIFF
--- a/data/repositories.xml
+++ b/data/repositories.xml
@@ -28,5 +28,7 @@
     <phar alias="carbon" composer="jpuck/carbon-console">
         <repository type="github" url="https://api.github.com/repos/jpuck/carbon-console/releases" />
     </phar>
-
+    <phar alias="phing" composer="phing/phing">
+        <repository type="github" url="https://api.github.com/repos/phingofficial/phing/releases" />
+    </phar>
 </repositories>


### PR DESCRIPTION
In https://github.com/phingofficial/phing/issues/633 the sha512 was added for phing. One release was made using this sha. More will follow when v3 is released