### PR TITLE
add composer-require-checker

### DIFF
--- a/data/repositories.xml
+++ b/data/repositories.xml
@@ -28,5 +28,8 @@
     <phar alias="carbon" composer="jpuck/carbon-console">
         <repository type="github" url="https://api.github.com/repos/jpuck/carbon-console/releases" />
     </phar>
+    <phar alias="composer-require-checker" composer="maglnet/composer-require-checker">
+        <repository type="github" url="https://api.github.com/repos/maglnet/ComposerRequireChecker/releases" />
+    </phar>
 
 </repositories>


### PR DESCRIPTION
Composer Require Checker is meant to check if all your dependencies are defined within your composer.json so this is a general development tool and imho useful to be installed with phive.

Se details here:
https://github.com/maglnet/ComposerRequireChecker