### PR TITLE
Alias for Phing

### DIFF
--- a/data/repositories.xml
+++ b/data/repositories.xml
@@ -50,6 +50,6 @@
         <repository type="github" url="https://api.github.com/repos/ktomk/pipelines/releases" />
     </phar>
     <phar alias="phing" composer="phing/phing">
-        <repository type="github" url="https://github.com/phingofficial/phing/releases" />
+        <repository type="github" url="https://api.github.com/repos/phingofficial/phing/releases" />
     </phar>
 </repositories>

--- a/data/repositories.xml
+++ b/data/repositories.xml
@@ -49,4 +49,7 @@
     <phar alias="pipelines" composer="ktomk/pipelines">
         <repository type="github" url="https://api.github.com/repos/ktomk/pipelines/releases" />
     </phar>
+    <phar alias="phing" composer="phing/phing">
+        <repository type="github" url="https://github.com/phingofficial/phing/releases" />
+    </phar>
 </repositories>


### PR DESCRIPTION
Phars & Singnatures are now available from the GitHub release page.