### PR TITLE
Adding `sshman` alias

### DIFF
--- a/data/repositories.xml
+++ b/data/repositories.xml
@@ -58,4 +58,7 @@
     <phar alias="clapi" composer="ngabor84/clapi">
         <repository type="github" url="https://api.github.com/repos/ngabor84/clapi/releases" />
     </phar>
+    <phar alias="sshman" composer="mwender/sshman">
+        <repository type="github" url="https://api.github.com/repos/mwender/sshman/releases" />
+    </phar>    
 </repositories>


### PR DESCRIPTION
I've made my CLI tool, [sshman](https://github.com/mwender/sshman/), available for install via PhiVE. This change will make my phar available via the `sshman` alias: `phive install sshman`.