### PR TITLE
Specifying wget output filename

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -75,8 +75,8 @@
                 <p class="big">Installation of PHIVE is easy and about the last time you have to do anything PHAR related manually.</p>
 
                 <p class="big">Grab your copy of PHIVE from the <a href="https://github.com/phar-io/phive/releases">releases section</a> or run these simple steps in a terminal:</p>
-                <pre><code>wget https://phar.io/releases/phive.phar
-wget https://phar.io/releases/phive.phar.asc
+                <pre><code>wget -O phive.phar https://phar.io/releases/phive.phar
+wget -O phive.phar.asc https://phar.io/releases/phive.phar.asc
 gpg --keyserver hkps.pool.sks-keyservers.net --recv-keys 0x9D8A98B29B2D5D79
 gpg --verify phive.phar.asc phive.phar
 chmod +x phive.phar


### PR DESCRIPTION
When I run `wget https://phar.io/releases/phive.phar`, the file saved to my hard drive looks like a hash from an AWS redirect (i.e. `b12fed34-3051-11e8-98be-5efe45af7912?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20180516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20180516T194921Z&X-Amz-Expires=300&X-Amz-Signature=e7a097f43919bd9f38dec9e`). 

Using wget's `--output-document` (i.e. `-O phive.phar` and `-O phive.phar.asc`) option makes sure the file gets saved with the proper filename. I think that doing this will make the install easier for users who don't catch what happened with the wget output filename.