### PR TITLE
Make clear that the phar names must be replaced

### DIFF
--- a/html/howto/sign-and-upload-to-github.html
+++ b/html/howto/sign-and-upload-to-github.html
@@ -38,14 +38,14 @@
 <div class="ym-wrapper layoutcnt2 alternatecolor1">
     <div class="ym-wbox">
         <h3 class="centered">Create a signature</h3>
-        <pre><code class="language-bash">gpg -u john@example.com --detach-sign --output your.phar.asc your.phar</code></pre>
+        <pre><code class="language-bash">gpg -u john@example.com --detach-sign --output {your_phar_name}.phar.asc {your_phar_name}.phar</code></pre>
         <p><strong>About the options:</strong></p>
         <ul>
             <li><strong>-u</strong> (optional) Provide a search term for the USER-ID you intend to use, if you have more
                 than one.
             </li>
             <li><strong>--detach-sign</strong> Create a detached signature (do not wrap the original file).</li>
-            <li><strong>--output</strong> Specify the filename of the signature (PHIVE currently searches for <code>your.phar.asc</code>).
+            <li><strong>--output</strong> Specify the filename of the signature (PHIVE currently searches for <code>{your_phar_name}.phar.asc</code>).
             </li>
         </ul>
         <p>Last argument is the PHAR you want to sign.</p>
@@ -57,7 +57,7 @@
         <ul>
             <li>Go to <code>https://github.com/&lt;your-vendor&gt;/&lt;your-project&gt;/releases</code></li>
             <li>Click &quot;Edit&quot; on your latest tag/release</li>
-            <li>Add <code>your.phar</code> and <code>your.phar.asc</code> in the &quot;Attach binaries...&quot; section
+            <li>Add <code>{your_phar_name}.phar</code> and <code>{your_phar_name}.phar.asc</code> in the &quot;Attach binaries...&quot; section
             </li>
             <li>Click &quot;Update release&quot;</li>
         </ul>


### PR DESCRIPTION
When I was following the guide, it wasn't 100 % clear what the name of the signature needs to be.
And seemingly, PHIVE actually supports to name the signature to be ``your.phar.asc``.

I like to use curved brackets for such replacement parts in guides as it makes the replacement parts more visible.

I hope this wording is now more clear.