### PR TITLE
Add metadata for roave/backward-compatibility-check

### DIFF
--- a/data/repositories.xml
+++ b/data/repositories.xml
@@ -111,4 +111,7 @@
     <phar alias="composer-normalize" composer="ergebnis/composer-normalize">
         <repository type="github" url="https://api.github.com/repos/ergebnis/composer-normalize/releases" />
     </phar>
+    <phar alias="backward-compatibility-check" composer="roave/backward-compatibility-check">
+        <repository type="github" url="https://api.github.com/repos/roave/BackwardCompatibilityCheck/releases" />
+    </phar>
 </repositories>


### PR DESCRIPTION
This makes it possible to install [Roave/BackwardCompatibilityCheck](https://github.com/Roave/BackwardCompatibilityCheck) using Phive.