### PR TITLE
Add PHP-Scoper alias

### DIFF
--- a/data/repositories.xml
+++ b/data/repositories.xml
@@ -141,4 +141,7 @@
     <phar alias="churn" composer="bmitch/churn-php">
         <repository type="github" url="https://api.github.com/repos/bmitch/churn-php/releases"/>
     </phar>
+    <phar alias="php-scoper" composer="humbug/php-scoper">
+        <repository type="github" url="https://api.github.com/repos/humbug/php-scoper/releases"/>
+    </phar>
 </repositories>


### PR DESCRIPTION
PHP-Scoper is now signed from 0.17.6 onwards.