### PR TITLE
Fix link

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -148,7 +148,7 @@ sudo mv phive.phar /usr/local/bin/phive</code></pre>
                             <li><a href="https://getcomposer.org">Composer</a></li>
                             <li><a href="https://cs.symfony.com">PHP CS Fixer</a></li>
                             <li><a href="https://github.com/phpstan/phpstan">PHPStan</a></li>
-                            <li><a href="https://www.dephpend.com/">dePHPend</a></li>
+                            <li><a href="https://dephpend.com/">dePHPend</a></li>
                             <li><a href="https://github.com/sebastianbergmann/phpcpd#readme">phpcpd</a></li>
                         </ul>
                     </div>


### PR DESCRIPTION
The previous URL leads to a unsafe exception in browser due to missing certificate on the www. subdomain
It will redirect to this URL anyway.