### PR TITLE
Add alias for flavioheleno/watchr

### DIFF
--- a/data/repositories.xml
+++ b/data/repositories.xml
@@ -147,6 +147,9 @@
     <phar alias="php-scoper" composer="humbug/php-scoper">
         <repository type="github" url="https://api.github.com/repos/humbug/php-scoper/releases"/>
     </phar>
+    <phar alias="watchr" composer="flavioheleno/watchr">
+        <repository type="github" url="https://api.github.com/repos/flavioheleno/watchr/releases"/>
+    </phar>
     <phar alias="yaml-lint" composer="j13k/yaml-lint">
         <repository type="github" url="https://api.github.com/repos/j13k/yaml-lint/releases"/>
     </phar>


### PR DESCRIPTION
[watchr](https://github.com/flavioheleno/watchr) is a command-line utility to check for Domain Name and TLS Certificates expiration dates.