### PR TITLE
Repositories: update for phpcs/phpcbf

### DIFF
--- a/data/repositories.xml
+++ b/data/repositories.xml
@@ -60,11 +60,11 @@
     <phar alias="phpstan" composer="phpstan/phpstan">
         <repository type="github" url="https://api.github.com/repos/phpstan/phpstan/releases" />
     </phar>
-    <phar alias="phpcs" composer="squizlabs/php_codesniffer">
-        <repository url="https://squizlabs.github.io/PHP_CodeSniffer/phars/phive.xml" />
+    <phar alias="phpcs" composer="phpcsstandards/php_codesniffer">
+        <repository url="https://phars.phpcodesniffer.com/phars/phive.xml" />
     </phar>
-    <phar alias="phpcbf" composer="squizlabs/php_codesniffer">
-        <repository url="https://squizlabs.github.io/PHP_CodeSniffer/phars/phive.xml" />
+    <phar alias="phpcbf" composer="phpcsstandards/php_codesniffer">
+        <repository url="https://phars.phpcodesniffer.com/phars/phive.xml" />
     </phar>
     <phar alias="n98-magerun" composer="n98/magerun">
         <repository url="https://files.magerun.net/phive.xml" />


### PR DESCRIPTION
The maintainer of PHPCS/PHPCBF has indicated they are abandoning the package.

The repo has now been forked and will continue to be maintained in the new location.

Ref:
* https://github.com/squizlabs/PHP_CodeSniffer/issues/3932