### PR TITLE
PHPCS/PHPCBF: small follow-up tweak

### DIFF
--- a/data/repositories.xml
+++ b/data/repositories.xml
@@ -60,10 +60,10 @@
     <phar alias="phpstan" composer="phpstan/phpstan">
         <repository type="github" url="https://api.github.com/repos/phpstan/phpstan/releases" />
     </phar>
-    <phar alias="phpcs" composer="phpcsstandards/php_codesniffer">
+    <phar alias="phpcs" composer="squizlabs/php_codesniffer">
         <repository url="https://phars.phpcodesniffer.com/phars/phive.xml" />
     </phar>
-    <phar alias="phpcbf" composer="phpcsstandards/php_codesniffer">
+    <phar alias="phpcbf" composer="squizlabs/php_codesniffer">
         <repository url="https://phars.phpcodesniffer.com/phars/phive.xml" />
     </phar>
     <phar alias="n98-magerun" composer="n98/magerun">


### PR DESCRIPTION
Follow up on #143

In contrast to earlier information, arrangements are now being made to allow the package to continue under its original name on Packagist. The commit (in the new repo) to rename the package [has been reverted](https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/135).

Sorry for the confusion and thank you for understanding.