### PR TITLE
feat: add buggregator/trap

### DIFF
--- a/data/repositories.xml
+++ b/data/repositories.xml
@@ -165,4 +165,7 @@
     <phar alias="eqivo" composer="rtckit/eqivo">
         <repository type="github" url="https://api.github.com/repos/rtckit/eqivo/releases"/>
     </phar>
+    <phar alias="trap" composer="buggregator/trap">
+        <repository type="github" url="https://api.github.com/repos/buggregator/trap/releases"/>
+    </phar>
 </repositories>


### PR DESCRIPTION
Hello 👋

I would like to add support for https://github.com/buggregator/trap

It is a debugging client for https://github.com/buggregator/server

GPG key ID: 04957006BD17BC1B

Tested installation using this command:

```bash
phive install https://github.com/buggregator/trap/releases/download/1.9.0/trap.phar
```
