### PR TITLE
fix(#169): deptrac alias, repo moved to "deptrac/deptrac"

### DIFF
--- a/data/repositories.xml
+++ b/data/repositories.xml
@@ -45,8 +45,8 @@
     <phar alias="dephpend" composer="dephpend/dephpend">
         <repository type="github" url="https://api.github.com/repos/mihaeu/dephpend/releases"/>
     </phar>
-    <phar alias="deptrac" composer="qossmic/deptrac">
-        <repository type="github" url="https://api.github.com/repos/qossmic/deptrac/releases"/>
+    <phar alias="deptrac" composer="deptrac/deptrac">
+        <repository type="github" url="https://api.github.com/repos/deptrac/deptrac/releases"/>
     </phar>
     <phar alias="doctum" composer="code-lts/doctum">
         <repository type="github" url="https://api.github.com/repos/code-lts/doctum/releases"/>


### PR DESCRIPTION
This PR corrects the `deptrac` aliases repository reference from `qossmic/deptrac` to `deptrac/deptrac`.

Fixes #169 