### PR TITLE
CaptainHook GitHub org rename

### DIFF
--- a/data/repositories.xml
+++ b/data/repositories.xml
@@ -10,7 +10,7 @@
         <repository type="github" url="https://api.github.com/repos/eliashaeussler/cache-warmup/releases"/>
     </phar>
     <phar alias="captainhook" composer="captainhook/captainhook">
-        <repository type="github" url="https://api.github.com/repos/captainhookphp/captainhook/releases"/>
+        <repository type="github" url="https://api.github.com/repos/captainhook-git/captainhook/releases"/>
     </phar>
     <phar alias="carbon" composer="jpuck/carbon-console">
         <repository type="github" url="https://api.github.com/repos/jpuck/carbon-console/releases"/>


### PR DESCRIPTION
The CaptainHook GitHub org was renamed so the repo url has to be updated