### PR TITLE
feat: add alias for phparkitect

### DIFF
--- a/data/repositories.xml
+++ b/data/repositories.xml
@@ -102,6 +102,9 @@
     <phar alias="phpab" composer="theseer/autoload">
         <repository type="github" url="https://api.github.com/repos/theseer/autoload/releases"/>
     </phar>
+    <phar alias="phparkitect" composer="phparkitect/phparkitect">
+        <repository type="github" url="https://api.github.com/repos/phparkitect/arkitect/releases"/>
+    </phar>
     <phar alias="phpbench" composer="phpbench/phpbench">
         <repository type="github" url="https://api.github.com/repos/phpbench/phpbench/releases"/>
     </phar>


### PR DESCRIPTION
See https://github.com/phparkitect/arkitect

A phar is available.  
It is signed with a GPG key.

